### PR TITLE
MES-8855 - fixed cat-d tests and fixed confirmation page not picking up field

### DIFF
--- a/src/features/des/cat-adi2/SuccessfulTests/0Faults.feature
+++ b/src/features/des/cat-adi2/SuccessfulTests/0Faults.feature
@@ -36,7 +36,7 @@ Feature: Cat-ADI2 Successful feature
       | testOutcome           | Passed       |
       | activityCode          | 1 - Pass     |
       | testCategory          | ADI2         |
-      | provLicenceRecieved   | na           |
+      | provLicenceReceived   | na           |
       | transmission          | na           |
       | d255                  | na           |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/cat-adi2/UnsuccessfulTests/7DrivingFaults.feature
+++ b/src/features/des/cat-adi2/UnsuccessfulTests/7DrivingFaults.feature
@@ -40,7 +40,7 @@ Feature: Cat-ADI2 Unsuccessful feature
       | testOutcome           | Unsuccessful |
       | activityCode          | 2 - Fail     |
       | testCategory          | ADI2         |
-      | provLicenceRecieved   | na           |
+      | provLicenceReceived   | na           |
       | transmission          | na           |
       | d255                  | na           |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/cat-b/SuccessfulTests/0Faults.feature
+++ b/src/features/des/cat-b/SuccessfulTests/0Faults.feature
@@ -38,7 +38,7 @@ Feature: Cat-B Successful feature
       | testOutcome           | Passed                                      |
       | activityCode          | 1 - Pass                                    |
       | testCategory          | B                                           |
-      | provLicenceRecieved   | Yes - Please retain the candidates licence  |
+      | provLicenceReceived   | Yes - Please retain the candidates licence  |
       | transmission          | Manual                                      |
       | d255                  | No                                          |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/cat-b/SuccessfulTests/15Faults.feature
+++ b/src/features/des/cat-b/SuccessfulTests/15Faults.feature
@@ -47,7 +47,7 @@ Feature: Cat-B Successful feature
       | testOutcome           | Passed                                      |
       | activityCode          | 1 - Pass                                    |
       | testCategory          | B                                           |
-      | provLicenceRecieved   | Yes - Please retain the candidates licence  |
+      | provLicenceReceived   | Yes - Please retain the candidates licence  |
       | transmission          | Manual                                      |
       | d255                  | No                                          |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/cat-b/SuccessfulTests/Rekey.feature
+++ b/src/features/des/cat-b/SuccessfulTests/Rekey.feature
@@ -37,7 +37,7 @@ Feature: Cat-B Successful feature
       | testOutcome           | Passed                                                        |
       | activityCode          | 1 - Pass                                                      |
       | testCategory          | B                                                             |
-      | provLicenceRecieved   | No - Please ensure that the licence is kept by the candidate  |
+      | provLicenceReceived   | No - Please ensure that the licence is kept by the candidate  |
       | transmission          | Automatic - An automatic licence issued                       |
       | d255                  | No                                                            |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/cat-b/SuccessfulTests/ValidationChecks.feature
+++ b/src/features/des/cat-b/SuccessfulTests/ValidationChecks.feature
@@ -74,7 +74,7 @@ Feature: Cat-B Successful feature
       | testOutcome           | Passed                                      |
       | activityCode          | 1 - Pass                                    |
       | testCategory          | B                                           |
-      | provLicenceRecieved   | Yes - Please retain the candidates licence  |
+      | provLicenceReceived   | Yes - Please retain the candidates licence  |
       | transmission          | Manual                                      |
       | d255                  | No                                          |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/cat-b/TerminatedTests/Code21.feature
+++ b/src/features/des/cat-b/TerminatedTests/Code21.feature
@@ -37,7 +37,7 @@ Feature: Cat-B Terminated feature
       | testOutcome           | Terminated                                                |
       | activityCode          | 21 - Vehicle / gear not suitable or no vehicle for test   |
       | testCategory          | B                                                         |
-      | provLicenceRecieved   | na                                                        |
+      | provLicenceReceived   | na                                                        |
       | transmission          | na                                                        |
       | d255                  | No                                                        |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/cat-b/TerminatedTests/Code4.feature
+++ b/src/features/des/cat-b/TerminatedTests/Code4.feature
@@ -38,7 +38,7 @@ Feature: Cat-B Terminated feature
       | testOutcome           | Unsuccessful                                     |
       | activityCode          | 4 - Fail in the interests of public safety       |
       | testCategory          | B                                                |
-      | provLicenceRecieved   | na                                               |
+      | provLicenceReceived   | na                                               |
       | transmission          | na                                               |
       | d255                  | No                                               |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/cat-b/TerminatedTests/Code5.feature
+++ b/src/features/des/cat-b/TerminatedTests/Code5.feature
@@ -38,7 +38,7 @@ Feature: Cat-B Terminated feature
       | testOutcome           | Unsuccessful                                               |
       | activityCode          | 5 - Fail candidate chose to stop test: Already failed      |
       | testCategory          | B                                                          |
-      | provLicenceRecieved   | na                                                         |
+      | provLicenceReceived   | na                                                         |
       | transmission          | na                                                         |
       | d255                  | No                                                         |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/cat-b/TerminatedTests/Rekey.feature
+++ b/src/features/des/cat-b/TerminatedTests/Rekey.feature
@@ -37,7 +37,7 @@ Feature: Cat-B Terminated with Rekey feature
       | testOutcome           | Terminated                                                    |
       | activityCode          | 25 - DVSA radio failure                                     |
       | testCategory          | B                                                             |
-      | provLicenceRecieved   | na                                                            |
+      | provLicenceReceived   | na                                                            |
       | transmission          | na                                                            |
       | d255                  | No                                                            |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/cat-b/TerminatedTests/ReturnToTestReport.feature
+++ b/src/features/des/cat-b/TerminatedTests/ReturnToTestReport.feature
@@ -34,7 +34,7 @@ Feature: Cat-B Terminated feature
       | testOutcome           | Passed                                      |
       | activityCode          | 1 - Pass                                    |
       | testCategory          | B                                           |
-      | provLicenceRecieved   | Yes - Please retain the candidates licence  |
+      | provLicenceReceived   | Yes - Please retain the candidates licence  |
       | transmission          | Manual                                      |
       | d255                  | No                                          |
     And I click on the button "des-final-confirmation-screen::back-to-debrief-btn"
@@ -53,7 +53,7 @@ Feature: Cat-B Terminated feature
       | testOutcome           | Terminated                                                |
       | activityCode          | 21 - Vehicle / gear not suitable or no vehicle for test   |
       | testCategory          | B                                                         |
-      | provLicenceRecieved   | na                                                        |
+      | provLicenceReceived   | na                                                        |
       | transmission          | na                                                        |
       | d255                  | No                                                        |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/cat-b/TerminatedTests/WaitingRoomDeclarationPage.feature
+++ b/src/features/des/cat-b/TerminatedTests/WaitingRoomDeclarationPage.feature
@@ -18,7 +18,7 @@ Feature: Cat-B Terminate Waiting Room Declaration feature
       | testOutcome           | Terminated                                               |
       | activityCode          | 21 - Vehicle / gear not suitable or no vehicle for test  |
       | testCategory          | B                                                         |
-      | provLicenceRecieved   | na                                                        |
+      | provLicenceReceived   | na                                                        |
       | transmission          | na                                                        |
       | d255                  | No                                                        |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/cat-b/TerminatedTests/WaitingRoomToCarPage.feature
+++ b/src/features/des/cat-b/TerminatedTests/WaitingRoomToCarPage.feature
@@ -24,7 +24,7 @@ Feature: Cat-B Terminated feature
       | testOutcome           | Terminated                                                 |
       | activityCode          | 27 - Language issues                                       |
       | testCategory          | B                                                          |
-      | provLicenceRecieved   | na                                                         |
+      | provLicenceReceived   | na                                                         |
       | transmission          | na                                                         |
       | d255                  | No                                                         |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/cat-b/UnsuccessfulTests/16Faults.feature
+++ b/src/features/des/cat-b/UnsuccessfulTests/16Faults.feature
@@ -38,7 +38,7 @@ Feature: Cat-B Unsuccessful feature
       | testOutcome           | Unsuccessful                                      |
       | activityCode          | 2 - Fail                                    |
       | testCategory          | B                                           |
-      | provLicenceRecieved   | na                                          |
+      | provLicenceReceived   | na                                          |
       | transmission          | na                                          |
       | d255                  | No                                          |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/cat-b/UnsuccessfulTests/DangerousFaults.feature
+++ b/src/features/des/cat-b/UnsuccessfulTests/DangerousFaults.feature
@@ -39,7 +39,7 @@ Feature: Cat-B Unsuccessful With Dangerous fault
       | testOutcome           | Unsuccessful                                      |
       | activityCode          | 2 - Fail                                    |
       | testCategory          | B                                           |
-      | provLicenceRecieved   | na                                          |
+      | provLicenceReceived   | na                                          |
       | transmission          | na                                          |
       | d255                  | No                                          |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/cat-b/UnsuccessfulTests/Eyesight.feature
+++ b/src/features/des/cat-b/UnsuccessfulTests/Eyesight.feature
@@ -29,7 +29,7 @@ Feature: Cat-B Unsuccessful With Eyesight feature
       | testOutcome           | Unsuccessful                                |
       | activityCode          | 3 - Fail due to eyesight                    |
       | testCategory          | B                                           |
-      | provLicenceRecieved   | na                                          |
+      | provLicenceReceived   | na                                          |
       | transmission          | na                                          |
       | d255                  | Yes - Please complete a D255                |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/cat-b/UnsuccessfulTests/Rekey.feature
+++ b/src/features/des/cat-b/UnsuccessfulTests/Rekey.feature
@@ -33,7 +33,7 @@ Feature: Cat-B Unsuccessful with serious faults feature Rekey
       | testOutcome           | Unsuccessful                                |
       | activityCode          | 2 - Fail                                    |
       | testCategory          | B                                           |
-      | provLicenceRecieved   | na                                          |
+      | provLicenceReceived   | na                                          |
       | transmission          | na                                          |
       | d255                  | Yes - Please complete a D255                |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/cat-b/UnsuccessfulTests/SeriousFault.feature
+++ b/src/features/des/cat-b/UnsuccessfulTests/SeriousFault.feature
@@ -34,7 +34,7 @@ Feature: Cat-B Unsuccessful with serious faults feature
       | testOutcome           | Unsuccessful                                |
       | activityCode          | 2 - Fail                                    |
       | testCategory          | B                                           |
-      | provLicenceRecieved   | na                                          |
+      | provLicenceReceived   | na                                          |
       | transmission          | na                                          |
       | d255                  | No                                          |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/cat-c/SuccessfulTests/15Faults.feature
+++ b/src/features/des/cat-c/SuccessfulTests/15Faults.feature
@@ -51,7 +51,7 @@ Feature: Cat-C Successful feature
       | testOutcome           | Passed                                      |
       | activityCode          | 1 - Pass                                    |
       | testCategory          | C                                           |
-      | provLicenceRecieved   | Yes - Please retain the candidates licence  |
+      | provLicenceReceived   | Yes - Please retain the candidates licence  |
       | transmission          | Manual                                      |
       | d255                  | No                                          |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/cat-c/UnsuccessfulTests/MultipleFaults.feature
+++ b/src/features/des/cat-c/UnsuccessfulTests/MultipleFaults.feature
@@ -52,7 +52,7 @@ Feature: Cat-C Unsuccessful Tests
       | testOutcome           | Unsuccessful                                |
       | activityCode          | 2 - Fail                                    |
       | testCategory          | C                                           |
-      | provLicenceRecieved   | na                                          |
+      | provLicenceReceived   | na                                          |
       | transmission          | na                                          |
       | d255                  | No                                          |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/cat-cpc/SuccessfulTests/0Faults.feature
+++ b/src/features/des/cat-cpc/SuccessfulTests/0Faults.feature
@@ -35,7 +35,7 @@ Feature: Cat-CPC Successful feature
       | testOutcome           | Passed                                      |
       | activityCode          | 1 - Pass                                    |
       | testCategory          | CCPC                                        |
-      | provLicenceRecieved   | na                                          |
+      | provLicenceReceived   | na                                          |
       | transmission          | na                                          |
       | d255                  | na                                          |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/cat-d/SuccessfulTests/10Faults.feature
+++ b/src/features/des/cat-d/SuccessfulTests/10Faults.feature
@@ -55,7 +55,7 @@ Feature: Cat-D Successful feature
       | testOutcome           | Passed                                      |
       | activityCode          | 1 - Pass                                    |
       | testCategory          | D                                           |
-      | provLicenceRecieved   | Yes - Please retain the candidates licence  |
+      | provLicenceReceived   | Yes - Please retain the candidates licence  |
       | transmission          | Manual                                      |
       | d255                  | No                                          |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/cat-d/UnsuccessfulTests/MultipleFaults.feature
+++ b/src/features/des/cat-d/UnsuccessfulTests/MultipleFaults.feature
@@ -1,4 +1,3 @@
-@test
 Feature: Cat-D Unsuccessful Tests
 
   Scenario: Unsuccessful test with multiple different faults

--- a/src/features/des/cat-d/UnsuccessfulTests/MultipleFaults.feature
+++ b/src/features/des/cat-d/UnsuccessfulTests/MultipleFaults.feature
@@ -1,3 +1,4 @@
+@test
 Feature: Cat-D Unsuccessful Tests
 
   Scenario: Unsuccessful test with multiple different faults
@@ -48,7 +49,7 @@ Feature: Cat-D Unsuccessful Tests
       | testOutcome           | Unsuccessful                                |
       | activityCode          | 2 - Fail                                    |
       | testCategory          | D                                           |
-      | provLicenceRecieved   | na                                          |
+      | provLicenceReceived   | na                                          |
       | transmission          | na                                          |
       | d255                  | No                                          |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/cat-home/SuccessfulTests/0Faults.feature
+++ b/src/features/des/cat-home/SuccessfulTests/0Faults.feature
@@ -36,7 +36,7 @@ Feature: Cat-G Home Successful feature
       | testOutcome           | Passed                                      |
       | activityCode          | 1 - Pass                                    |
       | testCategory          | G                                           |
-      | provLicenceRecieved   | Yes - Please retain the candidates licence  |
+      | provLicenceReceived   | Yes - Please retain the candidates licence  |
       | transmission          | Manual                                      |
       | d255                  | No                                          |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/cat-home/UnsuccessfulTests/16Faults.feature
+++ b/src/features/des/cat-home/UnsuccessfulTests/16Faults.feature
@@ -39,7 +39,7 @@ Feature: Cat-H Home Unsuccessful feature
       | testOutcome           | Unsuccessful                                |
       | activityCode          | 2 - Fail                                    |
       | testCategory          | H                                           |
-      | provLicenceRecieved   | na                                          |
+      | provLicenceReceived   | na                                          |
       | transmission          | na                                          |
       | d255                  | No                                          |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/mod1/SuccessfulTests/0Faults.feature
+++ b/src/features/des/mod1/SuccessfulTests/0Faults.feature
@@ -36,7 +36,7 @@ Feature: Cat-Mod1 Successful feature
       | testOutcome           | Passed                                                            |
       | activityCode          | 1 - Pass                                                          |
       | testCategory          | EUAMM1                                                            |
-      | provLicenceRecieved   | No - Please ensure that the licence is kept by the candidate      |
+      | provLicenceReceived   | No - Please ensure that the licence is kept by the candidate      |
       | transmission          | Automatic - An automatic licence issued                           |
       | d255                  | Yes - Please complete a D255                                      |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/mod1/UnsuccessfulTests/NotMeetingRequirements.feature
+++ b/src/features/des/mod1/UnsuccessfulTests/NotMeetingRequirements.feature
@@ -39,7 +39,7 @@ Feature: Cat-Mod1 Unsuccessful feature
       | testOutcome           | Unsuccessful                                 |
       | activityCode          | 4 - Fail in the interests of public safety   |
       | testCategory          | EUAMM1                                       |
-      | provLicenceRecieved   | na                                           |
+      | provLicenceReceived   | na                                           |
       | transmission          | na                                           |
       | d255                  | No                                           |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/mod2/SuccessfulTests/0Faults.feature
+++ b/src/features/des/mod2/SuccessfulTests/0Faults.feature
@@ -41,7 +41,7 @@ Feature: Cat-Mod2 Successful feature
       | testOutcome           | Passed                                                            |
       | activityCode          | 1 - Pass                                                          |
       | testCategory          | EUAMM2                                                            |
-      | provLicenceRecieved   | Yes - Please retain the candidates licence                        |
+      | provLicenceReceived   | Yes - Please retain the candidates licence                        |
       | transmission          | Automatic - An automatic licence issued                           |
       | d255                  | Yes - Please complete a D255                                      |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/features/des/mod2/UnsuccessfulTests/DangerousFaults.feature
+++ b/src/features/des/mod2/UnsuccessfulTests/DangerousFaults.feature
@@ -43,7 +43,7 @@ Feature: Cat-Mod2 Unsuccessful feature
       | testOutcome           | Unsuccessful                                 |
       | activityCode          | 2 - Fail                                     |
       | testCategory          | EUAMM2                                       |
-      | provLicenceRecieved   | na                                           |
+      | provLicenceReceived   | na                                           |
       | transmission          | na                                           |
       | d255                  | No                                           |
     And I click on the button "des-final-confirmation-screen::submit-test-results-btn"

--- a/src/pageobjects/des/confirmationPage.pageobject.ts
+++ b/src/pageobjects/des/confirmationPage.pageobject.ts
@@ -6,7 +6,7 @@ interface PassedConfirmationData {
   testOutcome: string;
   activityCode: string;
   testCategory: string;
-  provLicenceRecieved: string;
+  provLicenceReceived: string;
   transmission: string;
   d255: string;
   student: string;
@@ -73,7 +73,7 @@ class ConfirmationPageObject extends Page {
       testOutcome,
       activityCode,
       testCategory,
-      provLicenceRecieved,
+      provLicenceReceived,
       transmission,
       d255,
       student,
@@ -98,8 +98,8 @@ class ConfirmationPageObject extends Page {
           case 'testcategory':
             await checkEqualsText('element', this.testCategoryValue, false, testCategory);
             break;
-          case 'provisionlicence':
-            await checkEqualsText('element', this.provisionalLicencedValue, false, provLicenceRecieved);
+          case 'provlicencereceived':
+            await checkEqualsText('element', this.provisionalLicencedValue, false, provLicenceReceived);
             break;
           case 'transmission':
             await checkEqualsText('element', this.transmissionValue, false, transmission);

--- a/src/pageobjects/des/waitingRoomToCar.pageobject.ts
+++ b/src/pageobjects/des/waitingRoomToCar.pageobject.ts
@@ -237,6 +237,7 @@ class WaitingRoomPageToCarObject extends Page {
   get traineeLicenceNoLabel() { return ('des-waiting-room-to-car::trainee-licence-no-label'); }
 
   async addVehicleQuestion(question:string, value:string): Promise<void> {
+    await scroll(question);
     await clickElement('click', 'selector', question);
     await clickElementWithText('click', 'button', value);
     await clickElementWithText('click', 'element', 'Submit');
@@ -839,6 +840,7 @@ class WaitingRoomPageToCarObject extends Page {
   }
 
   async setShowMeQuestion1Fault(fieldInput:string) {
+    await scroll(this.firstVehicleCheckQuestionCorrectLabel);
     switch (fieldInput) {
       case 'correct':
         await clickElement('click', 'selector', this.firstVehicleCheckQuestionCorrectLabel);
@@ -852,6 +854,7 @@ class WaitingRoomPageToCarObject extends Page {
   }
 
   async setShowMeQuestion2Fault(fieldInput:string) {
+    await scroll(this.secondVehicleCheckQuestionCorrectLabel);
     switch (fieldInput) {
       case 'correct':
         await clickElement('click', 'selector', this.secondVehicleCheckQuestionCorrectLabel);
@@ -865,6 +868,7 @@ class WaitingRoomPageToCarObject extends Page {
   }
 
   async setShowMeQuestion3Fault(fieldInput:string) {
+    await scroll(this.thirdVehicleCheckQuestionCorrectLabel);
     switch (fieldInput) {
       case 'correct':
         await clickElement('click', 'selector', this.thirdVehicleCheckQuestionCorrectLabel);
@@ -878,6 +882,7 @@ class WaitingRoomPageToCarObject extends Page {
   }
 
   async setTellMeQuestion1Fault(fieldInput:string, category?:string) {
+    await scroll(category === 'adi2' ? this.firstVehicleCheckQuestionCorrectLabel : this.fourthVehicleCheckCorrectLabel);
     switch (fieldInput) {
       case 'correct':
         await clickElement(
@@ -899,6 +904,7 @@ class WaitingRoomPageToCarObject extends Page {
   }
 
   async setTellMeQuestion2Fault(fieldInput:string, category:string | undefined = 'na') {
+    await scroll(category === 'na' ? this.fifthVehicleCheckQuestionCorrectLabel : this.secondVehicleCheckQuestionCorrectLabel);
     switch (fieldInput) {
       case 'correct':
         await clickElement(


### PR DESCRIPTION
## Description

- Fixed both cat-d tests by adding a scroll function to scroll to what it needs to click
- Fixed confirmation page problem where it was not picking up the "Provision Licence Received" field.

https://dvsa.atlassian.net/browse/MES-8855

## Checklist

- [x] PR title includes the JIRA ticket number and an understandable description
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
